### PR TITLE
Remove setting of COMP_WORDBREAKS

### DIFF
--- a/lib/completion.sh
+++ b/lib/completion.sh
@@ -2,10 +2,6 @@
 # All rights reserved.
 
 ###-begin-{pkgname}-completion-###
-COMP_WORDBREAKS=${COMP_WORDBREAKS/=/}
-COMP_WORDBREAKS=${COMP_WORDBREAKS/@/}
-export COMP_WORDBREAKS
-
 if complete &>/dev/null; then
   _{pkgname}_completion () {
     local si="$IFS"


### PR DESCRIPTION
In some cases on Mac, we receive  "Trace/BPT trap: 5" error which is caused by incorrect value of COMP_WORDBREAKS environment variable. Remove the code which is adding values to it as we do not use = and @
This way we reduce the chance of setting incorrect value for this variable and if a problem with its value is detected, it should be traced back to npm or current system configuration.

Fixes http://teampulse.telerik.com/view#item/281740
